### PR TITLE
Fix desired accuracy initialiser

### DIFF
--- a/Sources/AsyncLocationKit/AsyncLocationManager.swift
+++ b/Sources/AsyncLocationKit/AsyncLocationManager.swift
@@ -35,17 +35,12 @@ public final class AsyncLocationManager {
     private var locationManager: CLLocationManager
     private var proxyDelegate: AsyncDelegateProxyInterface
     private var locationDelegate: CLLocationManagerDelegate
-    private var desiredAccuracy: LocationAccuracy = .bestAccuracy
     
-    public init() {
-        locationManager = CLLocationManager()
-        proxyDelegate = AsyncDelegateProxy()
-        locationDelegate = LocationDelegate(delegateProxy: proxyDelegate)
-        locationManager.delegate = locationDelegate
-        locationManager.desiredAccuracy = desiredAccuracy.convertingAccuracy
+    public convenience init(desiredAccuracy: LocationAccuracy = .bestAccuracy) {
+        self.init(locationManager: CLLocationManager(), desiredAccuracy: desiredAccuracy)
     }
-    
-    public init(locationManager: CLLocationManager, desiredAccuracy: LocationAccuracy) {
+
+    public init(locationManager: CLLocationManager, desiredAccuracy: LocationAccuracy = .bestAccuracy) {
         self.locationManager = locationManager
         proxyDelegate = AsyncDelegateProxy()
         locationDelegate = LocationDelegate(delegateProxy: proxyDelegate)
@@ -53,10 +48,6 @@ public final class AsyncLocationManager {
         self.locationManager.desiredAccuracy = desiredAccuracy.convertingAccuracy
     }
     
-    public convenience init(desiredAccuracy: LocationAccuracy) {
-        self.init()
-        self.desiredAccuracy = desiredAccuracy
-    }
     
     public func getAuthorizationStatus() -> CLAuthorizationStatus {
         if #available(iOS 14, *) {

--- a/Tests/AsyncLocationKitTests/AsyncLocationKitTests.swift
+++ b/Tests/AsyncLocationKitTests/AsyncLocationKitTests.swift
@@ -3,10 +3,21 @@ import CoreLocation
 @testable import AsyncLocationKit
 
 final class AsyncLocationKitTests: XCTestCase {
-    let locationManager = AsyncLocationManager(locationManager: MockLocationManager(), desiredAccuracy: .bestAccuracy)
+    static let mockLocationManager = MockLocationManager()
+    
+    func testDesiredAccuracy() {
+        let firstAccuracy: LocationAccuracy = .nearestTenMetersAccuracy
+        let locationManager = AsyncLocationManager(locationManager: AsyncLocationKitTests.mockLocationManager, desiredAccuracy: firstAccuracy)
+        XCTAssertTrue(AsyncLocationKitTests.mockLocationManager.desiredAccuracy == firstAccuracy.convertingAccuracy)
+
+        let secondAccuracy: LocationAccuracy = .bestForNavigationAccuracy
+        locationManager.updateAccuracy(with: secondAccuracy)
+        XCTAssertTrue(AsyncLocationKitTests.mockLocationManager.desiredAccuracy == secondAccuracy.convertingAccuracy)
+    }
     
     func testRequestLocation() async {
         do {
+            let locationManager = AsyncLocationManager(locationManager: AsyncLocationKitTests.mockLocationManager)
             let location = try await locationManager.requestLocation()
             
             switch location {


### PR DESCRIPTION
The convenience initialiser init(desiredAccuracy:) wasn't setting the desiredAccuracy of the wrapped LocationManager. This PR fixes the problem by using default parameters to remove the need for this initialiser.