### PR TITLE
Add allows background location update support

### DIFF
--- a/Sources/AsyncLocationKit/AsyncLocationManager.swift
+++ b/Sources/AsyncLocationKit/AsyncLocationManager.swift
@@ -36,16 +36,17 @@ public final class AsyncLocationManager {
     private var proxyDelegate: AsyncDelegateProxyInterface
     private var locationDelegate: CLLocationManagerDelegate
     
-    public convenience init(desiredAccuracy: LocationAccuracy = .bestAccuracy) {
+    public convenience init(desiredAccuracy: LocationAccuracy = .bestAccuracy, allowsBackgroundLocationUpdates: Bool = false) {
         self.init(locationManager: CLLocationManager(), desiredAccuracy: desiredAccuracy)
     }
 
-    public init(locationManager: CLLocationManager, desiredAccuracy: LocationAccuracy = .bestAccuracy) {
+    public init(locationManager: CLLocationManager, desiredAccuracy: LocationAccuracy = .bestAccuracy, allowsBackgroundLocationUpdates: Bool = false) {
         self.locationManager = locationManager
         proxyDelegate = AsyncDelegateProxy()
         locationDelegate = LocationDelegate(delegateProxy: proxyDelegate)
         self.locationManager.delegate = locationDelegate
         self.locationManager.desiredAccuracy = desiredAccuracy.convertingAccuracy
+        self.locationManager.allowsBackgroundLocationUpdates = allowsBackgroundLocationUpdates
     }
     
     
@@ -60,7 +61,11 @@ public final class AsyncLocationManager {
     public func updateAccuracy(with newAccuracy: LocationAccuracy) {
         locationManager.desiredAccuracy = newAccuracy.convertingAccuracy
     }
-    
+
+    public func updateAllowsBackgroundLocationUpdates(with newAllows: Bool) {
+        locationManager.allowsBackgroundLocationUpdates = newAllows
+    }
+
     @available(*, deprecated, message: "Use new function requestPermission(with:)")
     public func requestAuthorizationWhenInUse() async -> CLAuthorizationStatus {
         let authorizationPerformer = RequestAuthorizationPerformer()

--- a/Sources/AsyncLocationKit/AsyncLocationManager.swift
+++ b/Sources/AsyncLocationKit/AsyncLocationManager.swift
@@ -35,17 +35,12 @@ public final class AsyncLocationManager {
     private var locationManager: CLLocationManager
     private var proxyDelegate: AsyncDelegateProxyInterface
     private var locationDelegate: CLLocationManagerDelegate
-    private var desiredAccuracy: LocationAccuracy = .bestAccuracy
     
-    public init() {
-        locationManager = CLLocationManager()
-        proxyDelegate = AsyncDelegateProxy()
-        locationDelegate = LocationDelegate(delegateProxy: proxyDelegate)
-        locationManager.delegate = locationDelegate
-        locationManager.desiredAccuracy = desiredAccuracy.convertingAccuracy
+    public convenience init(desiredAccuracy: LocationAccuracy = .bestAccuracy) {
+        self.init(locationManager: CLLocationManager(), desiredAccuracy: desiredAccuracy)
     }
-    
-    public init(locationManager: CLLocationManager, desiredAccuracy: LocationAccuracy) {
+
+    public init(locationManager: CLLocationManager, desiredAccuracy: LocationAccuracy = .bestAccuracy) {
         self.locationManager = locationManager
         proxyDelegate = AsyncDelegateProxy()
         locationDelegate = LocationDelegate(delegateProxy: proxyDelegate)
@@ -53,10 +48,6 @@ public final class AsyncLocationManager {
         self.locationManager.desiredAccuracy = desiredAccuracy.convertingAccuracy
     }
     
-    public convenience init(desiredAccuracy: LocationAccuracy) {
-        self.init()
-        self.desiredAccuracy = desiredAccuracy
-    }
     
     public func getAuthorizationStatus() -> CLAuthorizationStatus {
         if #available(iOS 14, *) {

--- a/Tests/AsyncLocationKitTests/AsyncLocationKitTests.swift
+++ b/Tests/AsyncLocationKitTests/AsyncLocationKitTests.swift
@@ -3,10 +3,21 @@ import CoreLocation
 @testable import AsyncLocationKit
 
 final class AsyncLocationKitTests: XCTestCase {
-    let locationManager = AsyncLocationManager(locationManager: MockLocationManager(), desiredAccuracy: .bestAccuracy)
+    static let mockLocationManager = MockLocationManager()
+    
+    func testDesiredAccuracy() {
+        let firstAccuracy: LocationAccuracy = .nearestTenMetersAccuracy
+        let locationManager = AsyncLocationManager(locationManager: AsyncLocationKitTests.mockLocationManager, desiredAccuracy: firstAccuracy)
+        XCTAssertTrue(AsyncLocationKitTests.mockLocationManager.desiredAccuracy == firstAccuracy.convertingAccuracy)
+
+        let secondAccuracy: LocationAccuracy = .bestForNavigationAccuracy
+        locationManager.updateAccuracy(with: secondAccuracy)
+        XCTAssertTrue(AsyncLocationKitTests.mockLocationManager.desiredAccuracy == secondAccuracy.convertingAccuracy)
+    }
     
     func testRequestLocation() async {
         do {
+            let locationManager = AsyncLocationManager(locationManager: AsyncLocationKitTests.mockLocationManager)
             let location = try await locationManager.requestLocation()
             
             switch location {

--- a/Tests/AsyncLocationKitTests/AsyncLocationKitTests.swift
+++ b/Tests/AsyncLocationKitTests/AsyncLocationKitTests.swift
@@ -14,7 +14,17 @@ final class AsyncLocationKitTests: XCTestCase {
         locationManager.updateAccuracy(with: secondAccuracy)
         XCTAssertTrue(AsyncLocationKitTests.mockLocationManager.desiredAccuracy == secondAccuracy.convertingAccuracy)
     }
-    
+
+    func testAllowsBackgroundLocationUpdates() {
+        let firstAllows = true
+        let locationManager = AsyncLocationManager(locationManager: AsyncLocationKitTests.mockLocationManager, allowsBackgroundLocationUpdates: firstAllows)
+        XCTAssertTrue(AsyncLocationKitTests.mockLocationManager.allowsBackgroundLocationUpdates == firstAllows)
+
+        let secondAllows = false
+        locationManager.updateAllowsBackgroundLocationUpdates(with: secondAllows)
+        XCTAssertTrue(AsyncLocationKitTests.mockLocationManager.allowsBackgroundLocationUpdates == secondAllows)
+    }
+
     func testRequestLocation() async {
         do {
             let locationManager = AsyncLocationManager(locationManager: AsyncLocationKitTests.mockLocationManager)

--- a/Tests/AsyncLocationKitTests/LocationManager.swift
+++ b/Tests/AsyncLocationKitTests/LocationManager.swift
@@ -9,6 +9,17 @@ import Foundation
 import CoreLocation
 
 class MockLocationManager: CLLocationManager {
+    private var mockAllowsBackgroundLocationUpdates: Bool = false
+    
+    override var allowsBackgroundLocationUpdates: Bool {
+        get {
+            return mockAllowsBackgroundLocationUpdates
+        }
+        set {
+            mockAllowsBackgroundLocationUpdates = newValue
+        }
+    }
+    
     override var location: CLLocation? {
         return CLLocation(latitude: 100, longitude: 200)
     }


### PR DESCRIPTION
This PR adds support for initialising and updating allowsBackgroundLocationUpdates. It also includes a test for the new code. This code builds on my previous PR by using default parameters in the initialisers.