### PR TITLE
Fix AsyncDelegateProxy re-entrant cancellation crash

### DIFF
--- a/Sources/AsyncLocationKit/AsyncDelegateProxy.swift
+++ b/Sources/AsyncLocationKit/AsyncDelegateProxy.swift
@@ -68,11 +68,11 @@ final class AsyncDelegateProxy: AsyncDelegateProxyInterface {
     /// Handle method from delegate converted to **enum** case
     /// - Parameter event: case converting from method of normal delegate
     func eventForMethodInvoked(_ event: CoreLocationDelegateEvent) {
-        performersQueue.sync {
-            for performer in performers {
-                if performer.eventSupported(event) {
-                    performer.invokedMethod(event: event)
-                }
+        let currentPerformers = performersQueue.sync { performers }
+
+        for performer in currentPerformers {
+            if performer.eventSupported(event) {
+                performer.invokedMethod(event: event)
             }
         }
     }


### PR DESCRIPTION
Patched a crash in Sources/AsyncLocationKit/AsyncDelegateProxy.swift:70 by snapshotting performers under performersQueue and invoking performers after leaving the queue. That removes the re-entrant DispatchQueue.sync path that was trapping when a performer called cancellable?.cancel(for: self) during event delivery.